### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2196,7 +2196,7 @@
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -7936,7 +7936,7 @@
         "fs-extra": "^9.0.0",
         "glob": "^7.1.6",
         "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
+        "minimatch": ">=3.0.5",
         "schema-utils": "2.7.0",
         "semver": "^7.3.2",
         "tapable": "^1.0.0"
@@ -8266,7 +8266,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": ">=3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -9239,7 +9239,7 @@
         "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -14062,7 +14062,7 @@
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "dependencies": {
-        "minimatch": "3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -15437,7 +15437,7 @@
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "engines": {
         "node": ">=8"
@@ -18147,7 +18147,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       }
     },
     "@humanwhocodes/gitignore-to-minimatch": {
@@ -22355,7 +22355,7 @@
         "fs-extra": "^9.0.0",
         "glob": "^7.1.6",
         "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
+        "minimatch": ">=3.0.5",
         "schema-utils": "2.7.0",
         "semver": "^7.3.2",
         "tapable": "^1.0.0"
@@ -22573,7 +22573,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": ">=3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -23256,7 +23256,7 @@
         "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25066,7 +25066,7 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
-      "version": "3.1.2",
+      "version": ">=3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
@@ -26565,11 +26565,11 @@
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": ">=3.0.5"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.4",
+          "version": ">=3.0.5",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
@@ -27576,7 +27576,7 @@
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "minimatch": ">=3.0.5"
       }
     },
     "text-table": {


### PR DESCRIPTION
FIXED: A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service.