### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3003,7 +3003,7 @@
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
         "type-fest": ">=0.17.0 <3.0.0",
-        "webpack": ">=4.43.0 <6.0.0",
+        "webpack": ">=5.76.0",
         "webpack-dev-server": "3.x || 4.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
@@ -5864,7 +5864,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
@@ -5887,7 +5887,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       },
       "peerDependenciesMeta": {
         "@parcel/css": {
@@ -7264,7 +7264,7 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0",
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/eslint-webpack-plugin/node_modules/ajv": {
@@ -7776,7 +7776,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/filelist": {
@@ -7949,7 +7949,7 @@
         "eslint": ">= 6",
         "typescript": ">= 2.7",
         "vue-template-compiler": "*",
-        "webpack": ">= 4"
+        "webpack": ">=5.76.0"
       },
       "peerDependenciesMeta": {
         "eslint": {
@@ -8561,7 +8561,7 @@
         "url": "https://opencollective.com/html-webpack-plugin"
       },
       "peerDependencies": {
-        "webpack": "^5.20.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -11658,7 +11658,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv": {
@@ -12880,7 +12880,7 @@
       },
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/postcss-logical": {
@@ -14488,7 +14488,7 @@
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       },
       "peerDependenciesMeta": {
         "fibers": {
@@ -14817,7 +14817,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/source-map-resolve": {
@@ -15111,7 +15111,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/stylehacks": {
@@ -15411,7 +15411,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.1.0"
+        "webpack": ">=5.76.0"
       },
       "peerDependenciesMeta": {
         "@swc/core": {
@@ -15946,7 +15946,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/ajv": {
@@ -16044,7 +16044,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.37.0 || ^5.0.0"
+        "webpack": ">=5.76.0"
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
@@ -16133,7 +16133,7 @@
         "node": ">=12.22.0"
       },
       "peerDependencies": {
-        "webpack": "^4.44.2 || ^5.47.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/webpack-manifest-plugin/node_modules/source-map": {
@@ -16538,7 +16538,7 @@
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "webpack": "^4.4.0 || ^5.9.0"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/workbox-webpack-plugin/node_modules/source-map": {


### PR DESCRIPTION
Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.